### PR TITLE
Feat: #9 onMouseDown

### DIFF
--- a/my-editor/src/components/SpinBox.js
+++ b/my-editor/src/components/SpinBox.js
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 function SpinBox() {
   const [value, setValue] = useState(0);
+  const timerRef = useRef(null);
 
   const handleFocus = e => e.target.select();
   const handleChange = e => {
@@ -11,12 +12,24 @@ function SpinBox() {
     else
       setValue(Number.MAX_SAFE_INTEGER);
   }
-
-  const onClick = e => {
-    if (e.target.id === "inc-btn" && value < Number.MAX_SAFE_INTEGER)
-      setValue(value => value + 1);
-    if (e.target.id === "dec-btn" && value > 0)
-      setValue(value => value - 1);
+  const handleMouseDown = (e) => spinNum(e);
+  const handleMouseUp = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+  const handleClick = e => {
+    if (e.target.id === "inc-btn")
+      setValue(value => value < Number.MAX_SAFE_INTEGER ? value + 1 : value);
+    if (e.target.id === "dec-btn")
+      setValue(value => value > 0 ? value - 1 : value);
+  }
+  const spinNum = (e, delay = 500) => {
+    handleClick(e);
+    timerRef.current = setTimeout(() => {
+      return spinNum(e, delay > 100 ? delay * 0.7 : 100);
+    }, delay);
   }
 
   return (
@@ -27,9 +40,13 @@ function SpinBox() {
         onChange={handleChange}
         onFocus={handleFocus}
       />
-	    <div className="contorls">
-        <button id="inc-btn" type="button" onClick={onClick}>+</button>
-        <button id="dec-btn" type="button" onClick={onClick}>-</button>
+	    <div className="contorls"
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+      >
+        <button id="inc-btn" type="button">+</button>
+        <button id="dec-btn" type="button">-</button>
 	    </div>
     </div>
   );

--- a/my-editor/src/components/SpinBox.js
+++ b/my-editor/src/components/SpinBox.js
@@ -28,7 +28,7 @@ function SpinBox() {
   const spinNum = (e, delay = 500) => {
     handleClick(e);
     timerRef.current = setTimeout(() => {
-      return spinNum(e, delay > 100 ? delay * 0.7 : 100);
+      spinNum(e, delay > 100 ? delay * 0.7 : 100)
     }, delay);
   }
 


### PR DESCRIPTION
## 개요
- 이슈번호 #12 
- +/-버튼의 onMouseDown 이벤트를 구현했습니다

## 작업내용
- `setTimeout()`을 재귀 호출하여 delay가 점점 감소하도록 구현
- delay가 100ms 이하로 감소하지 않도록 설정

```
  const spinNum = (e, delay = 500) => {
    handleClick(e);
    timerRef.current = setTimeout(() => {
      spinNum(e, delay > 100 ? delay * 0.7 : 100)
    }, delay);
  }
```
